### PR TITLE
fix parse_captal_identifierは末尾に数値を受け入れる

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -358,7 +358,9 @@ fn parse_captal_identifier(input: &str) -> PResult<String> {
     let (input, head) = satisfy(|c| 'A' <= c && c <= 'Z' || c == '_')(input)?;
 
     // ([A..Z0..9]|_)*
-    let (input, tail) = many0(satisfy(|c| 'A' <= c && c <= 'Z' || c == '_'))(input)?;
+    let (input, tail) = many0(satisfy(|c| {
+        'A' <= c && c <= 'Z' || '0' <= c && c <= '9' || c == '_'
+    }))(input)?;
 
     let tail: String = tail.iter().collect();
     Ok((input, format!("{head}{tail}")))


### PR DESCRIPTION
## Why

- [PointFieldの型が期待と異なる定義になっていました](https://docs.rs/safe_drive/latest/safe_drive/msg/common_interfaces/sensor_msgs/msg/struct.PointField.html)
- 原因: 定数 or デフォルトの分類は識別子が大文字であることとなっており、大文字判定で末尾数字を受け入れてなかったため変数扱いとなっていました

```rs point_field.rs
#[repr(C)]
pub struct PointField {
    // 大文字のこれらは定数定義であることが期待される
    pub INT8: u8,
    pub UINT8: u8,
    pub INT16: u8,
    pub UINT16: u8,
    pub INT32: u8,
    pub UINT32: u8,
    pub FLOAT32: u8,
    pub FLOAT64: u8,

    // 期待するfieldは以下4つ
    pub name: RosString<0>,
    pub offset: u32,
    pub datatype: u8,
    pub count: u32,
}
```

[ROS2 `PointField.msg`](https://github.com/ros2/common_interfaces/blob/0ecd0f70791fe200f057b12bfc626beb21bad639/sensor_msgs/msg/PointField.msg#L3) の定義
```msg PointField.msg
# This message holds the description of one point entry in the
# PointCloud2 message format.
uint8 INT8    = 1
uint8 UINT8   = 2
uint8 INT16   = 3
uint8 UINT16  = 4
uint8 INT32   = 5
uint8 UINT32  = 6
uint8 FLOAT32 = 7
uint8 FLOAT64 = 8

# Common PointField names are x, y, z, intensity, rgb, rgba
string name      # Name of field
uint32 offset    # Offset from start of point struct
uint8  datatype  # Datatype enumeration, see above
uint32 count     # How many elements in the field
```

## What

- 末尾に数値を受け入れる修正をしました
- 手元で生成して、期待通りの型になることを確認しました

```
// This file was automatically generated by ros2msg_to_rs (https://github.com/tier4/ros2msg_to_rs).
use super::*;
use super::super::super::*;
use crate::msg::*;
use crate::rcl;
pub const INT8: u8 = 1;
pub const UINT8: u8 = 2;
pub const INT16: u8 = 3;
pub const UINT16: u8 = 4;
pub const INT32: u8 = 5;
pub const UINT32: u8 = 6;
pub const FLOAT32: u8 = 7;
pub const FLOAT64: u8 = 8;

extern "C" {
    fn sensor_msgs__msg__PointField__init(msg: *mut PointField) -> bool;
    fn sensor_msgs__msg__PointField__fini(msg: *mut PointField);
    fn sensor_msgs__msg__PointField__are_equal(lhs: *const PointField, rhs: *const PointField) -> bool;
    fn sensor_msgs__msg__PointField__Sequence__init(msg: *mut PointFieldSeqRaw, size: usize) -> bool;
    fn sensor_msgs__msg__PointField__Sequence__fini(msg: *mut PointFieldSeqRaw);
    fn sensor_msgs__msg__PointField__Sequence__are_equal(lhs: *const PointFieldSeqRaw, rhs: *const PointFieldSeqRaw) -> bool;
    fn rosidl_typesupport_c__get_message_type_support_handle__sensor_msgs__msg__PointField() -> *const rcl::rosidl_message_type_support_t;
}


#[repr(C)]
#[derive(Debug)]
pub struct PointField {
    pub name: crate::msg::RosString<0>,
    pub offset: u32,
    pub datatype: u8,
    pub count: u32,
}
```